### PR TITLE
Set cache=False for ephemerides

### DIFF
--- a/jwst_gtvt/find_tgt_info.py
+++ b/jwst_gtvt/find_tgt_info.py
@@ -103,7 +103,7 @@ def get_target_ephemeris(desg, start_date, end_date, smallbody=False):
                    epochs={'start':start_date, 'stop':end_date,
                    'step':'1d'})
 
-    eph = obj.ephemerides()
+    eph = obj.ephemerides(cache=False)
 
     return eph['targetname'][0], eph['RA'], eph['DEC']
 


### PR DESCRIPTION
Set query cache to JPLHORIZON to False to avoid failed queries. It slows the tool down if performing a query for a previously requested target but this solves some trouble when JPL changes things upstream.