### PR TITLE
Added utils script and entry point for deleting horizons cache

### DIFF
--- a/bin/delete_cache
+++ b/bin/delete_cache
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+"""
+Utility functions for package
+"""
+
+from jwst_gtvt.utils import delete_cache
+
+if __name__ == '__main__':
+    delete_cache()

--- a/jwst_gtvt/utils.py
+++ b/jwst_gtvt/utils.py
@@ -1,0 +1,38 @@
+"""
+Utility functions for package
+"""
+
+import astropy
+import os
+import shutil
+
+class Error(Exception):
+   """Base class for other exceptions"""
+   pass
+
+class ChoiceError(Error):
+   """Raised when input is not y or n"""
+   pass
+
+def delete_cache():
+    """Delete astroquery Horizons cache"""
+
+    cache = astropy.config.get_cache_dir()
+    horizons_cache = os.path.join(cache, 'astroquery', 'Horizons')
+
+    if os.path.exists(horizons_cache):
+        print('Horizons cache located: {}'.format(horizons_cache))
+        choice = input("Do you wish to delete this folder? [y/n]: ")
+
+        try:
+            if choice == 'y':
+                shutil.rmtree(horizons_cache)
+                print('Cache deleted..')
+            elif choice == 'n':
+                print('You chose to not delete the cache, exiting.')
+            else:
+                raise ChoiceError
+        except ChoiceError:
+            print('Input was not y or n, try again and provide valid input!')
+    else:
+        print('There is no Horizons cache available, exiting')

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     packages=['jwst_gtvt'],
-    scripts=['bin/jwst_gtvt', 'bin/jwst_mtvt'],
+    scripts=['bin/jwst_gtvt', 'bin/jwst_mtvt', 'bin/delete_cache'],
 
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed. For an analysis of "install_requires" vs pip's


### PR DESCRIPTION
This will allow users to enter `delete_cache` into the command line, and if the cache is there will offer the choice to delete it.