### PR TITLE
Add quantities argument to ephemerides call

### DIFF
--- a/jwst_gtvt/find_tgt_info.py
+++ b/jwst_gtvt/find_tgt_info.py
@@ -103,7 +103,7 @@ def get_target_ephemeris(desg, start_date, end_date, smallbody=False):
                    epochs={'start':start_date, 'stop':end_date,
                    'step':'1d'})
 
-    eph = obj.ephemerides(cache=False)
+    eph = obj.ephemerides(cache=False, quantities=(1))
 
     return eph['targetname'][0], eph['RA'], eph['DEC']
 


### PR DESCRIPTION
This should make the query more lightweight and also avoid all of the changes upstream at JPL. The `MTVT` only need targetname, ra, and dec to produce output. Quantity 1 returns all astrometric properties like RA, and Dec, we don't need all of the possible properties for our tool to run.