### PR TITLE
added python_requires to setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,8 @@ setup(
          'matplotlib',
          'astroquery',
      ],
+     
+     python_requires='<=3.7.0',
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
in this pull request I added a python_requires statement in the setup.py file specifying python versions <=3.7.0 are required to install the package. this is not a fix for issue #30 but it will prevent people from installing it with the wrong version and running into the problem. This is probably not required for MacOS versions other than 10.14.x. 

You may have a better idea in which case just reject the pull request....