### PR TITLE
Avoid matplotlib backend change, if backend is configured to Jupyter inline

### DIFF
--- a/jwst_gtvt/find_tgt_info.py
+++ b/jwst_gtvt/find_tgt_info.py
@@ -13,7 +13,9 @@ from astroquery.jplhorizons import Horizons
 import matplotlib.pyplot as plt
 
 import matplotlib
-matplotlib.use('TkAgg')
+# Use TkAgg backend by default, but don't change backend if called from a Jupyter notebook with inline plots
+if 'module://ipykernel.pylab.backend_inline' not in matplotlib.rcParams['backend']:
+    matplotlib.use('TkAgg')
 
 from matplotlib.dates import YearLocator, MonthLocator, DateFormatter
 import numpy as np


### PR DESCRIPTION
Right now the `find_tgt_info` file is hard-coded to change the matplotlib backend to TkAgg. This is not desirable. In particular, if the backend is set to the Jupyter inline plots backend (from e.g. `%matplotlib inline`), it should be left that way. 

The particular use case in which I ran into this problem is calling jwst_gtvt from MIRAGE, running remotely on a Jupyter server at the 'tute via ssh port forwarding. The TkAgg backend doesn't work at all in that case and trying to change the back end causes an exception that ends the program. 

With this change, it works as desired and I can call the `jwst_gtvt.find_tgt_info.get_table` from code running inside a notebook server. 

