### PR TITLE
Set long description in setup.py for publish-to-pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,10 @@ setup(
     version='0.3.0',
 
     description='JWST General Target Visibility Tool',
+    
+    long_description=long_description,
+    
+    long_description_content_type='text/markdown',
 
     # The project's main homepage.
     url='https://github.com/spacetelescope/jwst_gtvt',


### PR DESCRIPTION
Ensure `long_description` and `long_description_content_type` are correctly set in `setup.py`