### PR TITLE
Remove args from get_table function

### DIFF
--- a/jwst_gtvt/find_tgt_info.py
+++ b/jwst_gtvt/find_tgt_info.py
@@ -563,8 +563,8 @@ def get_table(ra, dec, instrument=None, start_date=None, end_date=None, save_tab
 
     A_eph = EPH.Ephemeris(join(dirname(abspath(__file__)), "horizons_EM_jwst_wrt_sun_2021-2024.txt"),ECL_FLAG, verbose=verbose)
 
-    search_start = Time(args.start_date, format='iso').mjd if args.start_date is not None else 59574.0  #Dec 26, 2021
-    search_end = Time(args.end_date, format='iso').mjd if args.end_date is not None else 60585.0  #Oct 02, 2024
+    search_start = Time(start_date, format='iso').mjd if start_date is not None else 59574.0  #Dec 26, 2021
+    search_end = Time(end_date, format='iso').mjd if end_date is not None else 60585.0  #Oct 02, 2024
 
     if not (59574.0 <= search_start <= 60586.0) and start_date is not None:
         raise ValueError('Start date {} outside of available ephemeris {} to {}'.format(start_date, '2021-12-26', '2024-10-02'))

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.3.0',
+    version='0.3.1',
 
     description='JWST General Target Visibility Tool',
     


### PR DESCRIPTION
Added args to the `get_table` by accident when performing a find and replace on `start_date` and `end_date`.