### PR TITLE
Update RA and DEC Parsing with Docopt

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+1.0.1
+=====
+- Bug fix: Negative declinations resulted in the GTVT throwing an
+  error because the argument parser accepts arguments that start with
+  '--' and '-', so was unable to interpret the minus sign. Updates to
+  the jwst_gtvt call were implemented to get around this issue by
+  requiring '--ra=' and '--dec=' in front of the right ascension and
+  declination values, respectively. The readme was updated with this information.
+
 1.0
 ===
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We also provide conda environments:
 
 There are two scripts available: `jwst_gtvt` for fixed targets and `jwst_mtvt` for moving targets. To see the help info use:
 
-    $ jwst_gtvt -h
+    $ jwst_gtvt --help
     Usage:
         jwst_gtvt --ra=<ra> --dec=<dec> [--start_date=<obs_start>] [--end_date=<obs_end>] [--instrument=<inst>] [--target_name=<name>] [--write_ephemeris=<write_path>] [--write_plot=<plot_path>] [--silent]
 

--- a/README.md
+++ b/README.md
@@ -41,26 +41,23 @@ We also provide conda environments:
 There are two scripts available: `jwst_gtvt` for fixed targets and `jwst_mtvt` for moving targets. To see the help info use:
 
     $ jwst_gtvt -h
-    
-    Driver for JWST GTVT fixed target tool.
-
     Usage:
-    jwst_gtvt --ra=<ra> --dec=<dec> [--start_date=<obs_start>] [--end_date=<obs_end>] [--instrument=<inst>] [--target_name=<name>] [--write_ephemeris=<write_path>] [--write_plot=<plot_path>] [--silent]
+        jwst_gtvt --ra=<ra> --dec=<dec> [--start_date=<obs_start>] [--end_date=<obs_end>] [--instrument=<inst>] [--target_name=<name>] [--write_ephemeris=<write_path>] [--write_plot=<plot_path>] [--silent]
 
     Arguments:
-    --ra=<ra>     Right ascension of target to observe with JWST.
-    --dec=<dec>   Declination of target to observe with JWST.
+        --ra=<ra>    Right ascension of target to observe with JWST.
+        --dec=<dec>   Declination of target to observe with JWST.
 
-    Options:
-    [--start_date]         Start date for plot
-    [--end_date]           End date for plot
-    [--instrument]         JWST instrument to plot individually
-    [--target_name]        User provided name for target
-    [--write_ephemeris]    File name to write ephemeris to
-    [--write_plot]         File name to write plot out to
-    [--silent]             Boolean to print results to screen [default: False]
-    --help                 Show this screen.
-    --version              Show version.
+        Options:
+        [--start_date]         Start date for plot
+        [--end_date]           End date for plot
+        [--instrument]         JWST instrument to plot individually
+        [--target_name]        User provided name for target
+        [--write_ephemeris]    File name to write ephemeris to
+        [--write_plot]         File name to write plot out to
+        [--silent]             Boolean to print results to screen [default: False]
+        -h --help              Show this screen.
+        --version              Show version.
 
 
 # Example

--- a/README.md
+++ b/README.md
@@ -41,23 +41,26 @@ We also provide conda environments:
 There are two scripts available: `jwst_gtvt` for fixed targets and `jwst_mtvt` for moving targets. To see the help info use:
 
     $ jwst_gtvt -h
+    
+    Driver for JWST GTVT fixed target tool.
+
     Usage:
-        jwst_gtvt <ra> <dec> [--start_date=<obs_start>] [--end_date=<obs_end>] [--instrument=<inst>] [--target_name=<name>] [--write_ephemeris=<write_path>] [--write_plot=<plot_path>] [--silent]
+    jwst_gtvt --ra=<ra> --dec=<dec> [--start_date=<obs_start>] [--end_date=<obs_end>] [--instrument=<inst>] [--target_name=<name>] [--write_ephemeris=<write_path>] [--write_plot=<plot_path>] [--silent]
 
     Arguments:
-        <ra>    Right ascension of target to observe with JWST.
-        <dec>   Declination of target to observe with JWST.
+    --ra=<ra>     Right ascension of target to observe with JWST.
+    --dec=<dec>   Declination of target to observe with JWST.
 
-        Options:
-        [--start_date]         Start date for plot
-        [--end_date]           End date for plot
-        [--instrument]         JWST instrument to plot individually
-        [--target_name]        User provided name for target
-        [--write_ephemeris]    File name to write ephemeris to
-        [--write_plot]         File name to write plot out to
-        [--silent]             Boolean to print results to screen [default: False]
-        -h --help              Show this screen.
-        --version              Show version.
+    Options:
+    [--start_date]         Start date for plot
+    [--end_date]           End date for plot
+    [--instrument]         JWST instrument to plot individually
+    [--target_name]        User provided name for target
+    [--write_ephemeris]    File name to write ephemeris to
+    [--write_plot]         File name to write plot out to
+    [--silent]             Boolean to print results to screen [default: False]
+    --help                 Show this screen.
+    --version              Show version.
 
 
 # Example
@@ -65,9 +68,9 @@ There are two scripts available: `jwst_gtvt` for fixed targets and `jwst_mtvt` f
 By default you need only specify R.A. and Dec. in either sexigesimal or degrees.
 The observability windows will be printed to the terminal and a plot showing the windows for each instrument will pop up.
 
-`$ jwst_gtvt 16:52:58.9 02:24:03`
+`$ jwst_gtvt --ra=16:52:58.9 --dec=02:24:03`
 
-`$ jwst_gtvt 253.2458 2.4008`
+`$ jwst_gtvt --ra=253.2458 --dec=2.4008`
 
 ![Example Plot](docs/jwst_target_visibility.png "Example default plot output.")
 
@@ -111,7 +114,7 @@ Occasionally there will be too many matching designations entries for a single t
 
 You can specify the instrument via the `--instrument` flag.
 
-`$ jwst_gtvt 16:52:58.9 02:24:03 --instrument nircam`,
+`$ jwst_gtvt --ra=16:52:58.9 --dec=02:24:03 --instrument nircam`,
 
 and the resulting plot will only contain the windows for the specified instrument.
 The allowed values for `--instrument` are 'nircam', 'nirspec', 'niriss', 'miri', 'fgs', and 'v3pa' (case insensitive).
@@ -120,7 +123,7 @@ The allowed values for `--instrument` are 'nircam', 'nirspec', 'niriss', 'miri',
 
 You can save the text and figure ouput to a file instead of having it output to terminal with `--write_ephemeris` and `--write_plot`.
 
-`$ jwst_gtvt 16:52:58.9 02:24:03 --write_ephemeris visibility.csv --write_plot visibility.png`
+`$ jwst_gtvt --ra=16:52:58.9 --dec=02:24:03 --write_ephemeris visibility.csv --write_plot visibility.png`
 
 Sharing output and reading data back in is easy:
 
@@ -144,13 +147,13 @@ Sharing output and reading data back in is easy:
 If you only want to plot a specific range of dates, rather than the entire available ephemeris you specify a `--start_date` or `--end_date` in ISO format (yyyy-mm-dd).
 For example:
 
-`$ jwst_gtvt 16:52:58.9 02:24:03 --target_name "NGC 6240" --start_date 2023-01-01 --end_date 2024-01-01`
+`$ jwst_gtvt --ra=16:52:58.9 --dec=02:24:03 --target_name "NGC 6240" --start_date 2023-01-01 --end_date 2024-01-01`
 
 ![Example Plot](docs/jwst_visibility_2023.png "Example plot output when specifying start and end dates.")
 
 Below is an example of the full text output:
 
-    $ jwst_gtvt 16:52:58.9 02:24:03
+    $ jwst_gtvt --ra=16:52:58.9 --dec=02:24:03
 
 
     +------------------------------------------+

--- a/jwst_gtvt/jwst_tvt.py
+++ b/jwst_gtvt/jwst_tvt.py
@@ -110,10 +110,10 @@ class Ephemeris:
         """Convert date ra dec to sexigesimal
         """
         aline = astring.split(':')
-        d= float(aline[0])
-        m= float(aline[1])
-        s= float(aline[2])
-        hour_or_deg = (s/60.+m)/60.+d
+        d = float(aline[0])
+        m = float(aline[1])
+        s = float(aline[2])
+        hour_or_deg = np.sign(d)*((s/60. + m)/60. + np.abs(d))
 
         return hour_or_deg
 

--- a/jwst_gtvt/jwst_tvt.py
+++ b/jwst_gtvt/jwst_tvt.py
@@ -113,7 +113,13 @@ class Ephemeris:
         d = float(aline[0])
         m = float(aline[1])
         s = float(aline[2])
-        hour_or_deg = np.sign(d)*((s/60. + m)/60. + np.abs(d))
+
+        sign = np.sign(d)
+
+        if sign != 0.0:
+            hour_or_deg = sign*((s/60. + m)/60. + np.abs(d))
+        else:
+            hour_or_deg = (s/60. + m)/60. + d
 
         return hour_or_deg
 

--- a/jwst_gtvt/scripts/jwst_gtvt.py
+++ b/jwst_gtvt/scripts/jwst_gtvt.py
@@ -1,13 +1,13 @@
 usage = """
 
-Database utility scripts.
+Driver for JWST GTVT fixed target tool.
 
 Usage:
-  jwst_gtvt <ra> <dec> [--start_date=<obs_start>] [--end_date=<obs_end>] [--instrument=<inst>] [--target_name=<name>] [--write_ephemeris=<write_path>] [--write_plot=<plot_path>] [--silent]
+  jwst_gtvt --ra=<ra> --dec=<dec> [--start_date=<obs_start>] [--end_date=<obs_end>] [--instrument=<inst>] [--target_name=<name>] [--write_ephemeris=<write_path>] [--write_plot=<plot_path>] [--silent]
 
 Arguments:
-  <ra>    Right ascension of target to observe with JWST.
-  <dec>   Declination of target to observe with JWST.
+  --ra=<ra>     Right ascension of target to observe with JWST.
+  --dec=<dec>   Declination of target to observe with JWST.
 
 Options:
   [--start_date]         Start date for plot
@@ -17,7 +17,7 @@ Options:
   [--write_ephemeris]    File name to write ephemeris to
   [--write_plot]         File name to write plot out to
   [--silent]             Boolean to print results to screen [default: False]
-  -h --help              Show this screen.
+  --help                 Show this screen.
   --version              Show version.
 """
 
@@ -41,7 +41,7 @@ def main(args):
     else:
         eph = Ephemeris()
 
-    eph.get_fixed_target_positions(args['<ra>'], args['<dec>'])
+    eph.get_fixed_target_positions(args['--ra'], args['--dec'])
 
     if not eph.dataframe['in_FOR'].any():
         in_FOR_msg = ("No position angles in field of regard! "


### PR DESCRIPTION
Addressing #90 

Docopt is having a hard time interpreting `-` for required arguments of RA and DEC. This PR adds `--ra=<ra>` and `--dec=<dec>` to our argument list replacing `<ra>` and `<dec>`. I updated the driver for the GTVT and the `README.md` to reflect these changes.