### PR TITLE
Fix Version Variable Name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,7 @@
+1.1.1 (2025-06-03)
+==================
+- Bug fix for version and function match.
+
 1.1 (2025-06-03)
 ================
 - Updated default start and end dates to cover the period from the current local date to 2 years in the future.

--- a/jwst_gtvt/display_results.py
+++ b/jwst_gtvt/display_results.py
@@ -9,10 +9,10 @@ def display_results(ephemeris):
     """print out results to screen"""
 
     now = datetime.datetime.now()
-    version = version("jwst_gtvt")
+    gtvt_version = version("jwst_gtvt")
     welcome_string = "JWST General Target Visibility Tool"
     date_string = "Runtime/Date: {}".format(now)
-    version_string = "Version Number: {}".format(version)
+    version_string = "Version Number: {}".format(gtvt_version)
 
     print(tabulate([[welcome_string],
                     [date_string],


### PR DESCRIPTION
Variable name took same name as imported function cause bug. This fixes the issue.