### PR TITLE
Calculate Ecliptic Latitude

### DIFF
--- a/jwst_gtvt/display_results.py
+++ b/jwst_gtvt/display_results.py
@@ -4,7 +4,6 @@ from importlib.metadata import version
 import pandas as pd
 from tabulate import tabulate
 
-
 def display_results(ephemeris):
     """print out results to screen"""
 
@@ -36,12 +35,16 @@ def display_results(ephemeris):
 
     df = ephemeris.dataframe
 
+    # For fixed targets, just get a single ra dec and calculuate value to display at top of output for GTVT
+    # else for moving targets, display ecliptic latitude in column since RA, Dec is changing with time
     if ephemeris.fixed is True:
         ra = max(df['ra'])
         dec = max(df['dec'])
-        target_info_string = 'RA: %-*s  Dec: %-*s  Ecliptic Latitude: %s' % (10, ra, 10, dec, 24.284867)
+        ecliptic_latitude = ephemeris.calculate_ecliptic_latitude(ra, dec)
+        target_info_string = 'RA: %-*s  Dec: %-*s  Ecliptic Latitude: %s' % (10, ra, 10, dec, ecliptic_latitude)
     else:
-        target_info_string = 'Target Name: %-*s Ecliptic Latitude: %s' % (10, ephemeris.target_name, 24.284867)
+        pa_columns["ecliptic_latitude"] = "Ecliptic Latitude"
+        target_info_string = 'Target Name: %-*s' % (10, ephemeris.target_name)
 
     df = df.loc[df['in_FOR']==True]
 

--- a/jwst_gtvt/display_results.py
+++ b/jwst_gtvt/display_results.py
@@ -43,7 +43,7 @@ def display_results(ephemeris):
         ecliptic_latitude = ephemeris.calculate_ecliptic_latitude(ra, dec)
         target_info_string = 'RA: %-*s  Dec: %-*s  Ecliptic Latitude: %s' % (10, ra, 10, dec, ecliptic_latitude)
     else:
-        pa_columns["ecliptic_latitude"] = "Ecliptic Latitude"
+        pa_columns["ecliptic_latitude"] = "Ecliptic Lat."
         target_info_string = 'Target Name: %-*s' % (10, ephemeris.target_name)
 
     df = df.loc[df['in_FOR']==True]

--- a/jwst_gtvt/jwst_tvt.py
+++ b/jwst_gtvt/jwst_tvt.py
@@ -120,6 +120,8 @@ class Ephemeris:
                 lambda x: mjd_epoch + timedelta(days=x)
             )
 
+            self.dataframe['Display Date'] = self.dataframe['Display Date'].dt.date
+
             # only build dataframe based on start and end date and reset the index
             self.dataframe = self.dataframe[
                 (self.dataframe["MJD"] >= self.start_date_mjd)

--- a/jwst_gtvt/jwst_tvt.py
+++ b/jwst_gtvt/jwst_tvt.py
@@ -21,6 +21,7 @@ Use
         >>> eph = Ephemeris()
 """
 
+from astropy.coordinates import SkyCoord
 from astropy.time import Time
 import astropy.units as u
 from astroquery.jplhorizons import Horizons
@@ -50,6 +51,7 @@ obliquity_of_the_ecliptic *= D2R
 # Qecl2eci = QX(obliquity_of_the_ecliptic)
 
 NOW = Time.now()
+
 
 class Ephemeris:
     def __init__(self, start_date=NOW, end_date=NOW + 2 * u.year):
@@ -114,7 +116,9 @@ class Ephemeris:
 
             # Create Display Calendar Date
             mjd_epoch = datetime(1858, 11, 17)
-            self.dataframe['Display Date'] = self.dataframe['MJD'].apply(lambda x: mjd_epoch + timedelta(days=x))
+            self.dataframe["Display Date"] = self.dataframe["MJD"].apply(
+                lambda x: mjd_epoch + timedelta(days=x)
+            )
 
             # only build dataframe based on start and end date and reset the index
             self.dataframe = self.dataframe[
@@ -127,6 +131,13 @@ class Ephemeris:
                 self.dataframe[coordinate] = (
                     self.dataframe[coordinate].shift() - self.dataframe[coordinate]
                 ) * 1 + self.dataframe[coordinate]
+
+    def calculate_ecliptic_latitude(self, ra, dec):
+        coord_eq = SkyCoord(ra=ra * u.degree, dec=dec * u.degree, frame="icrs")
+        coord_ecl = coord_eq.transform_to("barycentrictrueecliptic")
+        ecliptic_latitude = coord_ecl.lat.degree
+
+        return ecliptic_latitude
 
     def convert_ddmmss_to_float(self, astring):
         """Convert date ra dec to sexigesimal"""
@@ -565,7 +576,9 @@ class Ephemeris:
 
         self.dataframe["ra"] = eph["RA"].data.data
         self.dataframe["dec"] = eph["DEC"].data.data
-
+        self.dataframe["ecliptic_latitude"] = self.calculate_ecliptic_latitude(
+            self.dataframe["ra"].values, self.dataframe["dec"].values
+        )
         self.dataframe = self.build_dataframe()
 
         return self.dataframe


### PR DESCRIPTION
A user pointed out that the ecliptic latitude values for targets in the GTVT were incorrect. Looks like it was a bad copy paste job from when the tool was rewritten 2 years ago. The ecliptic latitude is calculated using astropy coordinate transforms.

The tool now calculates the ecliptic latitude for fixed and moving targets and displays them in the following ways:

GTVT: Since this handles fixed targets, the RA and Dec is fixed. The ecliptic latitude is calculated and displayed at the top of the output. Now it will display the correct ecliptic latitude.

MTVT: Since these targets have time dependent RA and Dec, we add the ecliptic latitude as column in the output.